### PR TITLE
creates local exporters dir

### DIFF
--- a/zeebe-cluster/templates/configmap.yaml
+++ b/zeebe-cluster/templates/configmap.yaml
@@ -30,6 +30,7 @@ data:
 
     
     if [ "$(ls -A /exporters/)" ]; then
+      mkdir /usr/local/zeebe/exporters/
       cp -a /exporters/*.jar /usr/local/zeebe/exporters/
     else  
       echo "No exporters available."


### PR DESCRIPTION
It creates the local (/usr/local/zeebe/exporters) dir before copying present (if any) exporters.